### PR TITLE
fix: fix calculating null string error and add brackets validation

### DIFF
--- a/simple-calculator/CalForm.cs
+++ b/simple-calculator/CalForm.cs
@@ -1,4 +1,5 @@
 ﻿using System.Data.SQLite;
+using System.Text.RegularExpressions;
 
 namespace simple_calculator
 {
@@ -194,6 +195,22 @@ namespace simple_calculator
             Sshu(ref b, ref c, 0, b.Length);
             return c[0];
         }
+        public static string ValidRightBrackets(string expression)
+        {
+            string pattern = @"\(\)";
+            Match match1 = Regex.Match(expression, pattern);
+            if (match1.Success)
+            {
+                expression = Regex.Replace(expression, @"\)*", "");
+            }
+            if (Regex.Count(expression, @"\(") < Regex.Count(expression, @"\)"))
+            {
+                Match match2 = Regex.Match(expression, @"\)", RegexOptions.RightToLeft);
+                expression = expression.Remove(match2.Index, 1);
+            }
+            return expression;
+        }
+        
 
 
         /// <summary>
@@ -204,6 +221,11 @@ namespace simple_calculator
         /// <exception cref="NotImplementedException"></exception>
         private void BtnEqual_Click(object sender, EventArgs e)
         {
+            if (display.Length == 0)
+            {
+                MessageBox.Show("请输入表达式！");
+                return;
+            }
             string ans = "";
             try
             {
@@ -349,6 +371,7 @@ namespace simple_calculator
         private void BtnRBracket_Click(object sender, EventArgs e)
         {
             display += ")";
+            display = ValidRightBrackets(display);
             UpdateDisplay();
         }
 

--- a/simple-calculatorTests/CalFormTests.cs
+++ b/simple-calculatorTests/CalFormTests.cs
@@ -55,5 +55,18 @@ namespace simple_calculator.Tests
             }
             catch {; }
         }
+
+        [TestMethod()]
+        [Timeout(2000)]
+        [DataRow("3.5+(2)", "3.5+(2)")]
+        [DataRow("3.5+2)", "3.5+2")]
+        [DataRow("3.5+()", "3.5+(")]
+        [DataRow("(3.5+(2))", "(3.5+(2))")]
+        [DataRow("(3.5+2))", "(3.5+2)")]
+        public void ValidRightBracketsTest(string expreesion, string expected)
+        {
+            string result = CalForm.ValidRightBrackets(expreesion);
+            Assert.AreEqual(expected, result);
+        }
     }
 }


### PR DESCRIPTION
Fix the issue when click equal twice or click equal when there is no input. Add validation to ensure that brackets are matched.